### PR TITLE
cp1616: cleanup build script and manifest

### DIFF
--- a/siemens_cp1616/CMakeLists.txt
+++ b/siemens_cp1616/CMakeLists.txt
@@ -1,58 +1,91 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(siemens_cp1616)
 
-find_package(catkin REQUIRED COMPONENTS 
-  roscpp
-  message_generation
-  )
-
-include_directories(${catkin_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/include/)
-
-ADD_LIBRARY(siemens_cp1616
-        ${PROJECT_SOURCE_DIR}/src/siemens_cp1616_io_controller.cpp
-        ${PROJECT_SOURCE_DIR}/src/siemens_cp1616_io_controller_callbacks.cpp
-        ${PROJECT_SOURCE_DIR}/src/siemens_cp1616_io_device.cpp
-        ${PROJECT_SOURCE_DIR}/src/siemens_cp1616_io_device_callbacks.cpp)
-
-add_service_files(FILES set_alarm.srv
-                        reset_alarm.srv)
-                        
-#Link CP1616 Library with yaml-cpp
-target_link_libraries (siemens_cp1616 yaml-cpp)
-     
-generate_messages(DEPENDENCIES)
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES siemens_cp1616
-  CATKIN_DEPENDS roscpp 
-  DEPENDS libpnoiusr libl2interface)
-
-#IO Controller wrapper
-add_executable(siemens_cp1616_io_controller_wrapper ${PROJECT_SOURCE_DIR}/src/siemens_cp1616_io_controller_wrapper.cpp)
-target_link_libraries(siemens_cp1616_io_controller_wrapper ${catkin_LIBRARIES} 
-                                                           siemens_cp1616
-                                                           libpniousr.a
-                                                           libl2interface.a                                                           
-                                                           pthread)
-#IO Device wrapper                                                   
-add_executable(siemens_cp1616_io_device_wrapper ${PROJECT_SOURCE_DIR}/src/siemens_cp1616_io_device_wrapper.cpp)
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS} siemens_cp1616_io_device_wrapper_gencpp)
-target_link_libraries(siemens_cp1616_io_device_wrapper ${catkin_LIBRARIES} 
-                                                       siemens_cp1616 
-                                                       libpniousr.a
-                                                       libl2interface.a                                                     
-                                                       pthread)
-
-
-## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_io_controller_wrapper ${PROJECT_NAME}_io_device_wrapper
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+find_package(catkin REQUIRED
+  COMPONENTS
+    message_generation
+    roscpp
+    std_msgs
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-   FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
-)                                       
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+add_service_files(
+  FILES
+    reset_alarm.srv
+    set_alarm.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    message_runtime
+    roscpp
+    std_msgs
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+)
+
+
+add_library(
+  ${PROJECT_NAME}
+  src/siemens_cp1616_io_controller.cpp
+  src/siemens_cp1616_io_controller_callbacks.cpp
+  src/siemens_cp1616_io_device.cpp
+  src/siemens_cp1616_io_device_callbacks.cpp
+)
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
+
+#IO Controller wrapper
+add_executable(
+  ${PROJECT_NAME}_io_controller_wrapper
+  src/siemens_cp1616_io_controller_wrapper.cpp)
+target_link_libraries(
+  ${PROJECT_NAME}_io_controller_wrapper
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  libpniousr.a
+  libl2interface.a
+  pthread
+)
+
+#IO Device wrapper
+add_executable(
+  ${PROJECT_NAME}_io_device_wrapper
+  src/siemens_cp1616_io_device_wrapper.cpp)
+add_dependencies(
+  ${PROJECT_NAME}_io_device_wrapper
+  siemens_cp1616_gencpp)
+target_link_libraries(
+  ${PROJECT_NAME}_io_device_wrapper
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  libpniousr.a
+  libl2interface.a
+  pthread
+)
+
+
+install(
+  TARGETS
+    ${PROJECT_NAME}
+    ${PROJECT_NAME}_io_controller_wrapper
+    ${PROJECT_NAME}_io_device_wrapper
+  RUNTIME
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  LIBRARY
+    DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(
+   DIRECTORY
+     include/${PROJECT_NAME}/
+   DESTINATION
+     ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)

--- a/siemens_cp1616/package.xml
+++ b/siemens_cp1616/package.xml
@@ -3,33 +3,28 @@
   <name>siemens_cp1616</name>
   <version>1.0.0</version>
   <description>
-    
-    The siemens_cp1616 is a package that allows the ROS user to communicate with Profinet IO devices 
-    using PCI communication card CP1616. The package itself wraps the functions of the IO Base 
-    library provided by Siemens and adopts them to ROS message/service functionality.  
-    
+    <p>
+      The siemens_cp1616 is a package that allows the ROS user to communicate with Profinet IO devices 
+      using PCI communication card CP1616. The package itself wraps the functions of the IO Base 
+      library provided by Siemens and adopts them to ROS message/service functionality.  
+    </p>
   </description>
 
   <author>Frantisek Durovsky </author>
   <maintainer email="frantisek.durovsky@smartroboticsys.eu">Frantisek Durovsky</maintainer>
   <license>Apache2.0</license>
-  
-  <url>http://www.ros.org/wiki/siemens_cp1616</url>
-  
+
+  <url>http://wiki.ros.org/siemens_cp1616</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>yaml-cpp</build_depend>   
-  <build_depend>std_srvs</build_depend>   
-  <build_depend>libpniousr</build_depend>   
-  <build_depend>libl2interface</build_depend>     
-  
+  <build_depend>std_msgs</build_depend>
+  <build_depend>yaml-cpp</build_depend>
+
+  <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
-  <run_depend>std_srvs</run_depend> 
-  <run_depend>libpniousr</run_depend> 
-  <run_depend>libl2interface</run_depend>   
-  
-  <export>
-    <rosdoc config="rosdoc.yaml" />   
-  </export>
 </package>


### PR DESCRIPTION
As per subject.

Some (minor) changes to `CMakeLists.txt`:
- don't prefix source file references with `PROJECT_SOURCE_DIR`: everything is already relative to the `CMakeLists.txt`
- add missing dependency declarations
- fixup service header generation
- re-indent all statements (follow ROS style guide)
- also install `siemens_cp1616` _library_

Still TODO:
- add `yaml-cpp` detection using FindPkg
- fix `link_target_libraries(..)` for `siemens_cp1616_io_device_wrapper` and `siemens_cp1616_io_controller_wrapper` targets
