### PR TITLE
cp1616: don't link yaml-cpp without searching for it

### DIFF
--- a/siemens_cp1616/CMakeLists.txt
+++ b/siemens_cp1616/CMakeLists.txt
@@ -8,7 +8,31 @@ find_package(catkin REQUIRED
     std_msgs
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(yaml_cpp REQUIRED yaml-cpp)
+if(NOT ${yaml_cpp_VERSION} VERSION_LESS "0.5")
+  add_definitions(-DHAVE_NEW_YAMLCPP)
+endif()
+
+find_path(
+  yaml_cpp_INCLUDE_DIR
+  # bit of a trick
+  NAMES yaml-cpp/yaml.h
+  PATHS ${yaml_cpp_INCLUDE_DIRS}
+)
+
+find_library(
+  yaml_cpp_LIBRARY
+  NAMES ${yaml_cpp_LIBRARIES}
+  PATHS ${yaml_cpp_LIBRARY_DIRS}
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${yaml_cpp_INCLUDE_DIR}
+)
+
 
 add_service_files(
   FILES
@@ -40,7 +64,7 @@ add_library(
   src/io_device.cpp
   src/io_device_callbacks.cpp
 )
-target_link_libraries(${PROJECT_NAME} yaml-cpp)
+target_link_libraries(${PROJECT_NAME} ${yaml_cpp_LIBRARY})
 
 #IO Controller wrapper
 add_executable(

--- a/siemens_cp1616/package.xml
+++ b/siemens_cp1616/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
+  <build_depend>pkg-config</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>


### PR DESCRIPTION
As per subject.

Tested on a Precise/Hydro and a Trusty/Indigo installation.
