### PR TITLE
cp1616: add note about not installing test files

### DIFF
--- a/siemens_cp1616/CMakeLists.txt
+++ b/siemens_cp1616/CMakeLists.txt
@@ -95,3 +95,6 @@ install(
    DESTINATION
      ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
+
+# NOTE: 'test_*.launch' and 'test_*.yaml' files are not part of the binary
+#       distribution and thus are not installed.


### PR DESCRIPTION
As per subject.

As discussed in #6.
